### PR TITLE
add getVolumeDescriptor method

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -133,6 +133,14 @@ final class Reader
         return fread($this->stream, $length);
     }
 
+   /**
+    * @return array
+    */
+    public function getVolumeDescriptor() : array
+    {
+        return $this->volumeDescriptor;
+    }
+
     /**
      * @return string[]
      */

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -195,4 +195,16 @@ RAW;
 
         self::assertNull($reader->getFile('unknownFile'));
     }
+
+    public function test getVolumeDescriptor()
+    {
+        $reader = new Reader(self::isoWithRockRidgePath);
+
+        $expected = 'CDROM                           ';
+
+        self::assertSame(
+          $expected,
+          $reader->getVolumeDescriptor()['VolumeIdentifier']
+        );
+    }
 }


### PR DESCRIPTION
I need access to some of the metadata in the volume descriptor - it would be pretty helpful to be able to get at that from the reader object!